### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node-lint.yml
+++ b/.github/workflows/node-lint.yml
@@ -7,6 +7,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   linting:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/timendum/freshportal/security/code-scanning/1](https://github.com/timendum/freshportal/security/code-scanning/1)

Add an explicit `permissions` block to the workflow with least privilege.  
Best fix here (without changing functionality) is to set workflow-level:

- `permissions:`
  - `contents: read`

This is sufficient for `actions/checkout` and linting steps that only read source code and install dependencies. Place it near the top-level keys (after `on:` block and before `jobs:`), so it applies to all jobs unless overridden later.

File to edit:
- `.github/workflows/node-lint.yml`  
Region:
- Insert new block between lines 9 and 10 (between `workflow_dispatch:` and `jobs:`).

No imports, methods, or extra definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
